### PR TITLE
[Dist/Debian] Use system libraries for ProtoBuf v3.12.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tensorflow (1.13.1+nns3) unstable; urgency=medium
+
+  * Instead of bundled ProtoBuf 3.6.1, Use system libraries of ProtoBuf
+    3.12.3, which is published by the NNStreamer PPA
+
+ -- Wook Song <wook16.song@samsung.com>  Wed, 30 Dec 2020 15:25:59 +0900
+
 tensorflow (1.13.1+nns2) unstable; urgency=medium
 
   * Revise debian packaging files to support Focal

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,8 @@ Build-Depends:
  g++-5 | g++-6 | g++-7 | g++-8,
  wget,
  zlib1g-dev,
+ libprotobuf-dev, libprotoc-dev,
+ protobuf-compiler,
  python-minimal | python-is-python3,
  python-numpy | python3-numpy,
  python-wheel | python3-wheel,

--- a/debian/rules
+++ b/debian/rules
@@ -44,7 +44,7 @@ endif
 override_dh_auto_build:
 ifeq ($(TENSORFLOW_BUILD), yes)
 	# If it's eoan (19.10), gcc-9 has some regressions. Use gcc-8 instead if it's eoan.
-	if [ -f /usr/bin/gcc-8 ]; then export CC=gcc-8; export CXX=g++-8; fi; ${topdir}/temp/usr/bin/bazel --output_user_root=${BAZEL_OUTPUT} build --verbose_failures --repository_cache=${packagingdir} --distdir=${packagingdir} -c opt //tensorflow/tools/lib_package:libtensorflow
+	if [ -f /usr/bin/gcc-8 ]; then export CC=gcc-8; export CXX=g++-8; fi; TF_SYSTEM_LIBS=protobuf_archive ${topdir}/temp/usr/bin/bazel --output_user_root=${BAZEL_OUTPUT} build --verbose_failures --repository_cache=${packagingdir} --distdir=${packagingdir} -c opt //tensorflow/tools/lib_package:libtensorflow
 endif
 
 	cd tensorflow/lite/tools/make && tar -xf ${packagingdir}/downloads.tar.gz


### PR DESCRIPTION
In order to fix [1], this patch modifies the 'rules' file to use system libraries of ProtoBuf v3.12.3, which is published by the NNStreamer PPA.

[1] https://github.com/nnstreamer/nnstreamer/issues/2985

Signed-off-by: Wook Song <wook16.song@samsung.com>